### PR TITLE
Fix missed messages when email is accidentally opened

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -522,7 +522,7 @@ def _poll_cycle(
     """Single poll iteration."""
     cleanup_old_attachments()
 
-    query = f"subject:{SUBJECT_PREFIX} is:unread"
+    query = f"subject:{SUBJECT_PREFIX} newer_than:1d"
     messages = search_messages(service, query)
 
     if not messages:


### PR DESCRIPTION
## Summary
- Replace `is:unread` with `newer_than:1d` in the Gmail search query
- Messages are now found even if you accidentally click/read them on your phone before the bridge polls
- The `processed_ids` set already prevents reprocessing, so `is:unread` was an unnecessary gate

## Test plan
- [ ] Open a `[claude]` email on your phone, then verify the bridge still picks it up and responds
- [ ] Verify already-processed messages are not re-processed (dedup via processed_ids)
- [ ] Verify the startup time guard still ignores old messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)