### PR TITLE
Strip [claude] prefix from email body and subject

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -15,6 +15,7 @@ import email.utils
 import json
 import logging
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -187,7 +188,6 @@ def strip_quoted_reply(text: str) -> str:
     Gmail format:  On Mon, Jan 1, 2026 at 10:00 Name <email> wrote:
     Outlook format: From: Name <email>
     """
-    import re
     # Gmail-style: "On ... wrote:" — may span lines and have blank lines before it
     match = re.search(r'\n\s*On .+?wrote:\s*$', text, re.DOTALL | re.MULTILINE)
     if match:
@@ -205,6 +205,11 @@ def strip_quoted_reply(text: str) -> str:
     while lines and lines[-1].lstrip().startswith(">"):
         lines.pop()
     return "\n".join(lines).strip()
+
+
+def strip_claude_prefix(text: str) -> str:
+    """Remove the [claude] subject prefix if present (case-insensitive)."""
+    return re.sub(r"^\[claude\]\s*", "", text, flags=re.IGNORECASE)
 
 
 def _extract_attachments(payload: dict) -> list[dict]:
@@ -593,6 +598,11 @@ def _poll_cycle(
 
         # Extract the user's question, stripping Gmail quoted reply text
         body = strip_quoted_reply(msg["body"].strip())
+        # Strip [claude] prefix from body and subject
+        body = strip_claude_prefix(body)
+        subject = strip_claude_prefix(msg["subject"])
+        if not body and subject:
+            body = subject
         if not body and not attachment_paths:
             log.info("Skipping message %s with empty body and no attachments", msg_id)
             mark_as_read(service, msg_id)

--- a/test_bridge.py
+++ b/test_bridge.py
@@ -327,5 +327,33 @@ class TestPreStartupSafety:
         assert new_msg_date_ms >= startup_ms
 
 
+
+
+# ---------------------------------------------------------------------------
+# strip_claude_prefix
+# ---------------------------------------------------------------------------
+
+
+class TestStripClaudePrefix:
+    """Tests for stripping the [claude] prefix from body and subject."""
+
+    def test_strip_lowercase_prefix(self):
+        assert bridge.strip_claude_prefix("[claude] what time is it?") == "what time is it?"
+
+    def test_strip_mixed_case_prefix(self):
+        assert bridge.strip_claude_prefix("[Claude] hello") == "hello"
+
+    def test_no_prefix_unchanged(self):
+        assert bridge.strip_claude_prefix("no prefix here") == "no prefix here"
+
+    def test_prefix_only_yields_empty(self):
+        assert bridge.strip_claude_prefix("[claude]") == ""
+
+    def test_prefix_with_extra_spaces(self):
+        assert bridge.strip_claude_prefix("[claude]   spaced out") == "spaced out"
+
+    def test_uppercase_prefix(self):
+        assert bridge.strip_claude_prefix("[CLAUDE] shout") == "shout"
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Adds `strip_claude_prefix()` helper that removes the `[claude]` prefix (case-insensitive) from text
- Strips the prefix from both the email body and subject after extraction in `_poll_cycle`
- Falls back to the stripped subject when the body is empty (handles emails where only the subject carries the question)
- Moves `import re` to top-level imports (was previously imported inline in `strip_quoted_reply`)

## Test plan
- [x] 6 new unit tests in `TestStripClaudePrefix` covering: lowercase, mixed case, no prefix, prefix-only, extra spaces, uppercase
- [x] All 36 tests pass (30 existing + 6 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)