### PR TITLE
Fix /sessions slug: replace dots with dashes

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -416,7 +416,7 @@ def invoke_claude(
 
 def list_sessions(count: int = 10) -> str:
     """List recent Claude Code sessions by reading JSONL files from disk."""
-    cwd_slug = CLAUDE_CWD.replace("/", "-")
+    cwd_slug = CLAUDE_CWD.replace("/", "-").replace(".", "-")
     sessions_dir = CLAUDE_SESSIONS_DIR / cwd_slug
     if not sessions_dir.exists():
         return "No sessions found."

--- a/test_bridge.py
+++ b/test_bridge.py
@@ -355,5 +355,48 @@ class TestStripClaudePrefix:
     def test_uppercase_prefix(self):
         assert bridge.strip_claude_prefix("[CLAUDE] shout") == "shout"
 
+
+# ---------------------------------------------------------------------------
+# list_sessions slug calculation
+# ---------------------------------------------------------------------------
+
+
+class TestListSessionsSlug:
+    """Slug must replace both '/' and '.' with '-'."""
+
+    def test_slug_replaces_dots_and_slashes(self, tmp_path):
+        """Paths like /Users/zhengli.sun/Projects produce correct slug."""
+        cwd = "/Users/zhengli.sun/Projects"
+        expected_slug = "-Users-zhengli-sun-Projects"
+
+        # Create a fake sessions directory matching the corrected slug
+        sessions_dir = tmp_path / expected_slug
+        sessions_dir.mkdir()
+        jsonl = sessions_dir / "session1.jsonl"
+        jsonl.write_text(json.dumps({"type": "summary", "summary": "test session"}) + "\n")
+
+        with mock.patch.object(bridge, "CLAUDE_CWD", cwd), \
+             mock.patch.object(bridge, "CLAUDE_SESSIONS_DIR", tmp_path):
+            result = bridge.list_sessions(count=5)
+
+        assert "session1" in result or "test session" in result
+
+    def test_slug_without_dot_fix_would_fail(self, tmp_path):
+        """Verify the old slug (dots NOT replaced) would miss the directory."""
+        cwd = "/Users/zhengli.sun/Projects"
+        wrong_slug = "-Users-zhengli.sun-Projects"  # dots kept
+
+        sessions_dir = tmp_path / wrong_slug
+        sessions_dir.mkdir()
+        jsonl = sessions_dir / "session1.jsonl"
+        jsonl.write_text(json.dumps({"type": "summary", "summary": "test"}) + "\n")
+
+        with mock.patch.object(bridge, "CLAUDE_CWD", cwd), \
+             mock.patch.object(bridge, "CLAUDE_SESSIONS_DIR", tmp_path):
+            result = bridge.list_sessions(count=5)
+
+        # The corrected code won't find the wrong-slug directory
+        assert result == "No sessions found."
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Fix `list_sessions()` slug calculation to replace `.` with `-` in addition to `/`
- The bug caused `/sessions` to look for directory `-Users-zhengli.sun-Projects` instead of the correct `-Users-zhengli-sun-Projects`
- Add two tests: one verifying the corrected slug finds sessions, one verifying the old (broken) slug misses them

## Test plan
- [x] `test_slug_replaces_dots_and_slashes` -- confirms corrected slug resolves to the right directory
- [x] `test_slug_without_dot_fix_would_fail` -- confirms the old slug (dots kept) would fail to find sessions
- [x] All 32 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)