### PR TITLE
Add /help command

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -60,6 +60,19 @@ ATTACHMENT_MAX_AGE_HOURS = 24
 PROGRESS_INTERVAL = 120  # seconds between "still working" emails
 CLAUDE_SESSIONS_DIR = Path.home() / ".claude" / "projects"
 
+HELP_TEXT = """\
+Available commands and capabilities:
+
+/help — Show this help message
+/sessions — List recent Claude Code sessions
+/resume <session-id> — Resume a specific session
+/cancel — Cancel a running task (coming soon)
+
+Regular messages — Sent to Claude Code for processing
+Attachments — Attach files to emails and Claude will analyze them
+Calendar, email, docs — Claude has access to Google Workspace tools
+Multi-turn — Reply in the same thread to continue a conversation"""
+
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
@@ -613,7 +626,16 @@ def _poll_cycle(
         thread_id = msg["thread_id"]
         log.info("Processing message %s in thread %s: %.80s", msg_id, thread_id, body)
 
-        # Built-in commands: /sessions and /resume <id>
+        # Built-in commands: /help, /sessions, and /resume <id>
+        if body.lower().strip() == "/help":
+            response = HELP_TEXT
+            send_reply(service, msg, response, my_email)
+            mark_as_read(service, msg_id)
+            processed_ids.add(msg_id)
+            save_processed_id(msg_id)
+            continue
+
+        # /sessions and /resume <id>
         if body.lower().strip() == "/sessions":
             response = list_sessions()
             send_reply(service, msg, response, my_email)

--- a/test_bridge.py
+++ b/test_bridge.py
@@ -398,5 +398,28 @@ class TestListSessionsSlug:
         # The corrected code won't find the wrong-slug directory
         assert result == "No sessions found."
 
+
+# ---------------------------------------------------------------------------
+# /help command
+# ---------------------------------------------------------------------------
+
+
+class TestHelpCommand:
+    """Verify HELP_TEXT contains key commands and capabilities."""
+
+    def test_help_text_contains_commands(self):
+        assert "/help" in bridge.HELP_TEXT
+        assert "/sessions" in bridge.HELP_TEXT
+        assert "/resume" in bridge.HELP_TEXT
+        assert "/cancel" in bridge.HELP_TEXT
+
+    def test_help_text_contains_capabilities(self):
+        assert "Attachments" in bridge.HELP_TEXT
+        assert "Multi-turn" in bridge.HELP_TEXT
+        assert "Google Workspace" in bridge.HELP_TEXT
+
+    def test_help_command_recognized(self):
+        body = bridge.strip_quoted_reply("/help")
+        assert body.lower() == "/help"
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Add a `/help` built-in command that replies with a list of all available commands and capabilities
- Define `HELP_TEXT` constant listing `/help`, `/sessions`, `/resume`, `/cancel`, and general capabilities (attachments, Google Workspace, multi-turn)
- Add `TestHelpCommand` test class verifying the help text contains key commands and capabilities

## Test plan
- [x] All 33 existing + new tests pass (`pytest test_bridge.py -v`)
- [ ] Manual: send an email with `/help` body and verify the reply contains the help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)