### PR TITLE
Change email trigger prefix from [claude] to cc

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ tail -f ~/.claude-remote/bridge.log
 Send an email **to yourself** with the subject:
 
 ```
-[claude] your question here
+cc your question here
 ```
 
 The bridge picks it up within ~30 seconds and replies in the same thread. Reply in the thread to continue the conversation (Claude retains context via sessions).
@@ -91,7 +91,7 @@ The bridge picks it up within ~30 seconds and replies in the same thread. Reply 
 ### Email Quality
 - **Rich HTML formatting** -- replies with code blocks, tables, and headings render as styled HTML in Gmail
 - **Quoted reply stripping** -- strips Gmail/Outlook quoted reply text so Claude only sees your new message
-- **`[claude]` prefix stripping** -- removes the prefix before sending to Claude so it gets a clean prompt
+- **`cc` prefix stripping** -- removes the prefix before sending to Claude so it gets a clean prompt
 - **Distinct sender** -- bridge replies show as "ClaudeRemote" so you can tell them apart
 
 ### Reliability
@@ -161,7 +161,7 @@ Edit the constants at the top of `bridge.py`:
 | `CLAUDE_TIMEOUT` | `600` | Max seconds per Claude invocation |
 | `MAX_RESPONSE_LEN` | `50000` | Truncate replies beyond this length |
 | `CLAUDE_CWD` | `~/Projects` | Working directory for Claude |
-| `SUBJECT_PREFIX` | `[claude]` | Email subject prefix to watch for |
+| `SUBJECT_PREFIX` | `cc` | Email subject prefix to watch for |
 | `REPLY_SENDER_NAME` | `ClaudeRemote` | Display name on reply emails |
 | `MAX_ATTACHMENT_SIZE` | `10MB` | Skip attachments larger than this |
 | `PROGRESS_INTERVAL` | `120` | Seconds between "still working" progress emails |
@@ -172,7 +172,7 @@ Edit the constants at the top of `bridge.py`:
 ## Security
 
 - **Sender check**: only processes emails from your own address
-- **Subject gate**: only emails with `[claude]` prefix
+- **Subject gate**: only emails with `cc` prefix
 - **Rate limiting**: 20 invocations/hour cap prevents runaway costs
 - **Startup safety**: ignores all existing emails on daemon start
 - **Local only**: all processing on your laptop, Gmail API over HTTPS

--- a/bridge.py
+++ b/bridge.py
@@ -1,7 +1,7 @@
 #!/Users/zhengli.sun/Projects/claude-remote/.venv/bin/python
 """ClaudeRemote: Gmail remote interface for Claude Code.
 
-Polls Gmail for emails with [claude] subject prefix, feeds them to Claude Code
+Polls Gmail for emails with "cc" subject prefix, feeds them to Claude Code
 via subprocess, and replies in the same email thread.
 
 Usage:
@@ -53,7 +53,7 @@ POLL_INTERVAL = 30  # seconds
 CLAUDE_TIMEOUT = 600  # 10 minutes
 MAX_RESPONSE_LEN = 50_000  # chars
 CLAUDE_CWD = "/Users/zhengli.sun/Projects"
-SUBJECT_PREFIX = "[claude]"
+SUBJECT_PREFIX = "cc"
 REPLY_SENDER_NAME = "ClaudeRemote"  # Display name on reply emails
 ATTACHMENTS_DIR = CONFIG_DIR / "attachments"
 MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024  # 10 MB
@@ -257,17 +257,17 @@ def strip_quoted_reply(text: str) -> str:
 
 
 def strip_claude_prefix(text: str) -> str:
-    """Remove the [claude] subject prefix if present (case-insensitive)."""
-    return re.sub(r"^\[claude\]\s*", "", text, flags=re.IGNORECASE)
+    """Remove the 'cc' subject prefix if present (case-insensitive)."""
+    return re.sub(r"^cc\b\s*", "", text, flags=re.IGNORECASE)
 
 
 def generate_subject(body: str, max_len: int = 50) -> str:
     """Generate a short subject line from the user's message."""
     first_line = body.split("\n")[0].strip()
-    first_line = re.sub(r'^\[claude\]\s*', '', first_line, flags=re.IGNORECASE)
+    first_line = re.sub(r'^cc\b\s*', '', first_line, flags=re.IGNORECASE)
     if len(first_line) > max_len:
         first_line = first_line[:max_len].rsplit(" ", 1)[0] + "..."
-    return f"[claude] {first_line}" if first_line else "[claude] conversation"
+    return f"cc {first_line}" if first_line else "cc conversation"
 
 
 def _extract_attachments(payload: dict) -> list[dict]:
@@ -527,7 +527,7 @@ def invoke_claude(
                 output = (
                     f"[Claude exited with code {proc.returncode}]\n\n"
                     + (f"Error: {stderr_text}\n\n" if stderr_text else "")
-                    + "Reply in this thread to retry, or start a new thread with [claude] prefix."
+                    + "Reply in this thread to retry, or start a new thread with cc prefix."
                 )
             if not output:
                 output = (

--- a/test_bridge.py
+++ b/test_bridge.py
@@ -288,7 +288,7 @@ class TestSendReplyFromName:
     def test_from_header_has_display_name(self):
         """Verify the MIME message has ClaudeRemote as display name."""
         original_msg = {
-            "subject": "[claude] test",
+            "subject": "cc test",
             "from": "Zhengli Sun <zhengli.sun@doordash.com>",
             "message_id": "<abc@gmail.com>",
             "references": "",
@@ -309,7 +309,7 @@ class TestSendReplyFromName:
         decoded = base64.urlsafe_b64decode(raw).decode()
 
         assert f"{bridge.REPLY_SENDER_NAME} <{my_email}>" in decoded
-        assert "Re: [claude] test" in decoded
+        assert "Re: cc test" in decoded
 
 
 # ---------------------------------------------------------------------------
@@ -338,25 +338,28 @@ class TestPreStartupSafety:
 
 
 class TestStripClaudePrefix:
-    """Tests for stripping the [claude] prefix from body and subject."""
+    """Tests for stripping the 'cc' prefix from body and subject."""
 
     def test_strip_lowercase_prefix(self):
-        assert bridge.strip_claude_prefix("[claude] what time is it?") == "what time is it?"
+        assert bridge.strip_claude_prefix("cc what time is it?") == "what time is it?"
 
     def test_strip_mixed_case_prefix(self):
-        assert bridge.strip_claude_prefix("[Claude] hello") == "hello"
+        assert bridge.strip_claude_prefix("Cc hello") == "hello"
 
     def test_no_prefix_unchanged(self):
         assert bridge.strip_claude_prefix("no prefix here") == "no prefix here"
 
     def test_prefix_only_yields_empty(self):
-        assert bridge.strip_claude_prefix("[claude]") == ""
+        assert bridge.strip_claude_prefix("cc") == ""
 
     def test_prefix_with_extra_spaces(self):
-        assert bridge.strip_claude_prefix("[claude]   spaced out") == "spaced out"
+        assert bridge.strip_claude_prefix("cc   spaced out") == "spaced out"
 
     def test_uppercase_prefix(self):
-        assert bridge.strip_claude_prefix("[CLAUDE] shout") == "shout"
+        assert bridge.strip_claude_prefix("CC shout") == "shout"
+
+    def test_cc_inside_word_unchanged(self):
+        assert bridge.strip_claude_prefix("account info") == "account info"
 
 
 # ---------------------------------------------------------------------------
@@ -528,22 +531,22 @@ class TestDailyDigest:
 class TestGenerateSubject:
     def test_short_message(self):
         result = bridge.generate_subject("How do I fix the login bug?")
-        assert result == "[claude] How do I fix the login bug?"
+        assert result == "cc How do I fix the login bug?"
 
     def test_long_message_truncated(self):
         long_msg = "Please refactor the authentication module to use OAuth2 instead of the legacy token system"
         result = bridge.generate_subject(long_msg)
         assert result.endswith("...")
-        assert len(result) <= 60  # [claude] prefix + 50 + ...
+        assert len(result) <= 57  # "cc " prefix + 50 + ...
 
-    def test_claude_prefix_stripped(self):
-        result = bridge.generate_subject("[claude] deploy the new service")
-        assert result == "[claude] deploy the new service"
-        assert "[claude] [claude]" not in result
+    def test_cc_prefix_stripped(self):
+        result = bridge.generate_subject("cc deploy the new service")
+        assert result == "cc deploy the new service"
+        assert "cc cc" not in result
 
     def test_empty_message_fallback(self):
-        assert bridge.generate_subject("") == "[claude] conversation"
-        assert bridge.generate_subject("   ") == "[claude] conversation"
+        assert bridge.generate_subject("") == "cc conversation"
+        assert bridge.generate_subject("   ") == "cc conversation"
 
 # ---------------------------------------------------------------------------
 # invoke_claude error messages
@@ -634,7 +637,7 @@ class TestFormatHtmlReply:
     def test_plain_text_no_markdown(self):
         """Simple text without markdown markers stays as plain MIMEText."""
         original_msg = {
-            "subject": "[claude] test",
+            "subject": "cc test",
             "from": "User <user@example.com>",
             "message_id": "<abc@gmail.com>",
             "references": "",


### PR DESCRIPTION
## Summary
- Changed `SUBJECT_PREFIX` from `[claude]` to `cc` for easier mobile typing
- Updated regex patterns in `strip_claude_prefix` and `generate_subject` to use word-boundary matching (`\bcc\b`)
- Updated all tests and README references

## Test plan
- [x] All 64 tests pass (including new test for "cc inside word unchanged")
- [x] Regex uses `\b` word boundary to avoid matching "cc" inside words like "account"

🤖 Generated with [Claude Code](https://claude.com/claude-code)