### PR TITLE
Add token auto-refresh, optional skills, and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ Gmail-only commands:
 |---------|-------------|
 | `/sessions` | List your 10 most recent Claude Code sessions |
 | `/resume <id>` | Resume any session by ID |
-| `/summary` | Generate an end-of-day work summary |
-| `/brief` | Generate a morning briefing |
+| `/summary` | Generate an end-of-day work summary (requires `/summary` skill) |
+| `/brief` | Generate a morning briefing (requires `/brief` skill) |
 
 ## Features
 
@@ -153,7 +153,7 @@ Gmail-only commands:
 - **File attachments** - send images, PDFs, or code files and Claude will analyze them
 - **Progress emails** - sends "still working..." replies every 2 minutes for long tasks
 - **Smart thread naming** - first reply uses a descriptive subject line
-- **Scheduled emails** - daily digest (5am GMT) and work summary (10pm local)
+- **Scheduled emails** - daily digest (5am GMT) and work summary (10pm local), only if the `/brief` and `/summary` skills are installed in `~/.claude/skills/`
 
 ### Slack-specific
 - **$0 polling** - reads Slack via direct MCP HTTP calls (no LLM involved in polling)

--- a/bridge.py
+++ b/bridge.py
@@ -719,6 +719,14 @@ def _record_invocation():
 # ---------------------------------------------------------------------------
 
 
+CLAUDE_SKILLS_DIR = Path.home() / ".claude" / "skills"
+
+
+def _skill_exists(skill_name: str) -> bool:
+    """Check if a Claude Code skill is installed."""
+    return (CLAUDE_SKILLS_DIR / skill_name).is_dir()
+
+
 def _invoke_skill(skill_name: str) -> str:
     """Invoke a Claude Code skill (e.g. /brief, /summary) via claude -p."""
     return invoke_claude(f"/{skill_name}", str(uuid.uuid4()), resume=False)
@@ -745,6 +753,10 @@ def send_daily_digest(service, my_email: str, thread_sessions: dict, processed_c
         last_sent = DIGEST_LAST_SENT_FILE.read_text().strip()
         if last_sent == now.strftime("%Y-%m-%d"):
             return
+
+    if not _skill_exists("brief"):
+        log.debug("Skipping morning briefing: /brief skill not installed")
+        return
 
     log.info("Generating morning briefing via /brief skill")
     body = _invoke_skill("brief")
@@ -784,6 +796,10 @@ def send_work_summary(service, my_email: str):
         last_sent = SUMMARY_LAST_SENT_FILE.read_text().strip()
         if last_sent == now.strftime("%Y-%m-%d"):
             return
+
+    if not _skill_exists("summary"):
+        log.debug("Skipping work summary: /summary skill not installed")
+        return
 
     log.info("Generating work summary via /summary skill")
     body = _invoke_skill("summary")
@@ -920,6 +936,13 @@ def gmail_poll_cycle(
             save_processed_id(msg_id)
             continue
         if body.lower() == "/summary":
+            if not _skill_exists("summary"):
+                response = "The /summary skill is not installed. Create it at ~/.claude/skills/summary/"
+                send_reply(service, msg, response, my_email)
+                mark_as_read(service, msg_id)
+                processed_ids.add(msg_id)
+                save_processed_id(msg_id)
+                continue
             log.info("Manual work summary requested via /summary skill")
             response = _invoke_skill("summary")
             summary_sent = send_reply(service, msg, response, my_email)
@@ -932,6 +955,13 @@ def gmail_poll_cycle(
             save_processed_id(msg_id)
             continue
         if body.lower() == "/brief":
+            if not _skill_exists("brief"):
+                response = "The /brief skill is not installed. Create it at ~/.claude/skills/brief/"
+                send_reply(service, msg, response, my_email)
+                mark_as_read(service, msg_id)
+                processed_ids.add(msg_id)
+                save_processed_id(msg_id)
+                continue
             log.info("Manual morning brief requested via /brief skill")
             response = _invoke_skill("brief")
             brief_sent = send_reply(service, msg, response, my_email)


### PR DESCRIPTION
## Summary
- **Token auto-refresh**: Auto-refresh Slack OAuth token when < 2 hours remaining (configurable via `CLAUDE_REMOTE_SLACK_REFRESH_HOURS`, default 2, set 0 to disable). Sends Slack notification if refresh fails with re-auth instructions
- **Optional skills**: `/brief` and `/summary` scheduled emails and manual commands now check if the skill exists in `~/.claude/skills/` before invoking. Silently skips for scheduled emails; returns helpful message for manual commands. This avoids "Unknown skill" errors for users who don't have these skills installed
- **README update**: Comprehensive rewrite covering session resume, token refresh, thread lifecycle, env config, updated project structure and configuration table

## Test plan
- [x] Verified refresh token works (tested manually, got new access token + refresh token)
- [x] Verified auto-refresh skips when token has > 2 hours remaining
- [x] Verified `/brief` skill does not exist in `~/.claude/skills/` — scheduled email now silently skips
- [ ] Verify auto-refresh triggers when token has < 2 hours remaining
- [ ] Verify Slack notification sent on refresh failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)