### PR TITLE
Address Copilot review feedback from PR #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Create `~/.claude-remote/env` to override settings, or edit constants at the top
 
 | Setting | Default | Env var | Description |
 |---------|---------|---------|-------------|
-| `POLL_INTERVAL` | `30` | `CLAUDE_REMOTE_POLL_INTERVAL` | Seconds between polls |
+| `POLL_INTERVAL` | `15` | `CLAUDE_REMOTE_POLL_INTERVAL` | Seconds between polls |
 | `CLAUDE_TIMEOUT` | `600` | - | Max seconds per Claude invocation |
 | `MAX_RESPONSE_LEN` | `50000` | - | Truncate replies beyond this |
 | `CLAUDE_CWD` | `~/Projects` | `CLAUDE_REMOTE_CWD` | Working directory for Claude |
@@ -233,4 +233,4 @@ Create `~/.claude-remote/env` to override settings, or edit constants at the top
 - **Rate limiting**: 20 invocations/hour cap prevents runaway costs
 - **Startup safety**: ignores all existing messages on daemon start
 - **Local only**: all processing on your laptop, API calls over HTTPS
-- **Token security**: OAuth credentials stored in `~/.claude-remote/` (chmod 600)
+- **Token security**: OAuth credentials stored in `~/.claude-remote/` (dir chmod 700, secret files chmod 600)

--- a/bridge.py
+++ b/bridge.py
@@ -1132,6 +1132,7 @@ SLACK_TOKEN_FILE = CONFIG_DIR / "slack_mcp_token.json"
 SLACK_MCP_CLIENT_ID = "1601185624273.8899143856786"
 # Refresh token when it has less than this many hours left (0 = disabled)
 SLACK_TOKEN_REFRESH_HOURS = int(os.environ.get("CLAUDE_REMOTE_SLACK_REFRESH_HOURS", "2"))
+_script_dir = Path(__file__).resolve().parent
 
 
 def _notify_refresh_failure(entry: dict, error_msg: str):
@@ -1145,7 +1146,7 @@ def _notify_refresh_failure(entry: dict, error_msg: str):
         if channel_id:
             msg = (
                 f"{AGENT_PREFIX} :warning: {error_msg}\n"
-                f"Run `cd ~/Projects/claude-remote && .venv/bin/python slack_oauth.py` to re-authenticate."
+                f"Run `cd {_script_dir} && .venv/bin/python slack_oauth.py` to re-authenticate."
             )
             _mcp_call("slack_send_message", {
                 "channel_id": channel_id,
@@ -1243,7 +1244,7 @@ def get_slack_token() -> Optional[str]:
 
         if now_ms > expires_at:
             # Token expired — try refresh before giving up
-            if SLACK_TOKEN_REFRESH_HOURS > 0:
+            if SLACK_TOKEN_REFRESH_HOURS > 0 and entry.get("refreshToken"):
                 refreshed = _refresh_slack_token(entry)
                 if refreshed:
                     return refreshed["accessToken"]
@@ -1254,11 +1255,14 @@ def get_slack_token() -> Optional[str]:
             return None
 
         if SLACK_TOKEN_REFRESH_HOURS > 0 and remaining_hours < SLACK_TOKEN_REFRESH_HOURS:
-            log.info("Slack token expires in %.1f hours, refreshing proactively", remaining_hours)
-            refreshed = _refresh_slack_token(entry)
-            if refreshed:
-                return refreshed["accessToken"]
-            # If refresh fails, continue with current token
+            if entry.get("refreshToken"):
+                log.info("Slack token expires in %.1f hours, refreshing proactively", remaining_hours)
+                refreshed = _refresh_slack_token(entry)
+                if refreshed:
+                    return refreshed["accessToken"]
+            else:
+                log.debug("Slack token expires in %.1f hours but no refresh token available", remaining_hours)
+            # If refresh fails or no refresh token, continue with current token
 
     return entry["accessToken"]
 
@@ -1531,6 +1535,13 @@ def save_slack_state(state: dict):
 # Slack Poll Cycle
 # ---------------------------------------------------------------------------
 
+SLACK_POSTING_RULE = (
+    "SLACK POSTING RULE: You may ONLY post to the current thread "
+    "(channel {channel_id}, thread_ts {thread_ts}). "
+    "Do NOT post to any other channel, thread, or DM unless the user explicitly asks you to. "
+    "Do NOT start new threads or send DMs."
+)
+
 
 def slack_poll_cycle(token: str, state: dict):
     """Single Slack poll iteration."""
@@ -1643,7 +1654,9 @@ def slack_poll_cycle(token: str, state: dict):
             prompt = text
         elif msg["is_thread_reply"]:
             thread_context = msg.get("thread_context", "")
+            posting_rule = SLACK_POSTING_RULE.format(channel_id=channel_id, thread_ts=thread_ts)
             prompt = (
+                f"{posting_rule}\n\n"
                 f"You are an AI assistant replying in a Slack thread. "
                 f"Here is the full thread context:\n\n{thread_context}\n\n"
                 f"The latest message is: {text}\n\n"
@@ -1652,7 +1665,9 @@ def slack_poll_cycle(token: str, state: dict):
                 f"Use all available MCP tools if needed."
             )
         else:
+            posting_rule = SLACK_POSTING_RULE.format(channel_id=channel_id, thread_ts=thread_ts)
             prompt = (
+                f"{posting_rule}\n\n"
                 f"You are an AI assistant responding to a Slack message. "
                 f"The message is: {text}\n\n"
                 f"Process this as a task. Use all available MCP tools "
@@ -1671,7 +1686,9 @@ def slack_poll_cycle(token: str, state: dict):
             session_id = str(uuid.uuid4())
             thread_context = msg.get("thread_context", "")
             if thread_context:
+                posting_rule = SLACK_POSTING_RULE.format(channel_id=channel_id, thread_ts=thread_ts)
                 prompt = (
+                    f"{posting_rule}\n\n"
                     f"You are an AI assistant replying in a Slack thread. "
                     f"Here is the full thread context:\n\n{thread_context}\n\n"
                     f"The latest message is: {text}\n\n"
@@ -1680,7 +1697,9 @@ def slack_poll_cycle(token: str, state: dict):
                     f"Use all available MCP tools if needed."
                 )
             else:
+                posting_rule = SLACK_POSTING_RULE.format(channel_id=channel_id, thread_ts=thread_ts)
                 prompt = (
+                    f"{posting_rule}\n\n"
                     f"You are an AI assistant responding to a Slack message. "
                     f"The message is: {text}\n\n"
                     f"Process this as a task. Use all available MCP tools "

--- a/test_bridge.py
+++ b/test_bridge.py
@@ -466,7 +466,7 @@ class TestDailyDigest:
         send_mock = mock_service.users.return_value.messages.return_value.send
         send_mock.return_value.execute.return_value = {"id": "d1"}
 
-        with mock.patch.object(bridge, "_invoke_skill", return_value="# Morning Brief\nTest content") as mock_skill:
+        with mock.patch.object(bridge, "_skill_exists", return_value=True),              mock.patch.object(bridge, "_invoke_skill", return_value="# Morning Brief\nTest content") as mock_skill:
             bridge.send_daily_digest(mock_service, "me@test.com", {}, 0)
 
         mock_skill.assert_called_once_with("brief")
@@ -478,11 +478,25 @@ class TestDailyDigest:
         send_mock = mock_service.users.return_value.messages.return_value.send
         send_mock.return_value.execute.return_value = {"id": "d1"}
 
-        with mock.patch.object(bridge, "_invoke_skill", return_value="# Summary\nTest") as mock_skill:
+        with mock.patch.object(bridge, "_skill_exists", return_value=True),              mock.patch.object(bridge, "_invoke_skill", return_value="# Summary\nTest") as mock_skill:
             bridge.send_work_summary(mock_service, "me@test.com")
 
         mock_skill.assert_called_once_with("summary")
         send_mock.assert_called_once()
+
+    def test_digest_skipped_if_brief_skill_missing(self, tmp_config):
+        """Digest must not send if /brief skill directory is missing."""
+        mock_service = mock.MagicMock()
+        with mock.patch.object(bridge, "_skill_exists", return_value=False):
+            bridge.send_daily_digest(mock_service, "me@test.com", {}, 0)
+        mock_service.users().messages().send.assert_not_called()
+
+    def test_summary_skipped_if_summary_skill_missing(self, tmp_config):
+        """Work summary must not send if /summary skill directory is missing."""
+        mock_service = mock.MagicMock()
+        with mock.patch.object(bridge, "_skill_exists", return_value=False):
+            bridge.send_work_summary(mock_service, "me@test.com")
+        mock_service.users().messages().send.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -819,6 +833,89 @@ class TestSlackTokenManagement:
         with mock.patch.object(bridge, "CREDENTIALS_FILE", creds_file):
             token = bridge.get_slack_token()
         assert token is None
+
+
+class TestSlackTokenRefresh:
+    """Tests for Slack token auto-refresh."""
+
+    def test_refresh_success(self, tmp_config):
+        """Successful refresh returns new entry and writes token file."""
+        entry = {
+            "serverUrl": "https://mcp.slack.com/mcp",
+            "accessToken": "old-token",
+            "refreshToken": "refresh-123",
+            "expiresAt": int(time.time() * 1000) - 1000,
+        }
+        mock_response = json.dumps({
+            "ok": True,
+            "access_token": "new-token",
+            "refresh_token": "refresh-456",
+            "expires_in": 43200,
+        }).encode()
+
+        token_file = tmp_config / "slack_mcp_token.json"
+        with mock.patch.object(bridge, "SLACK_TOKEN_FILE", token_file), \
+             mock.patch("bridge.urlopen") as mock_urlopen:
+            mock_resp = mock.MagicMock()
+            mock_resp.read.return_value = mock_response
+            mock_resp.__enter__ = mock.MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = mock.MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_resp
+
+            result = bridge._refresh_slack_token(entry)
+
+        assert result is not None
+        assert result["accessToken"] == "new-token"
+        assert result["refreshToken"] == "refresh-456"
+        assert token_file.exists()
+
+    def test_refresh_no_refresh_token(self, tmp_config):
+        """Refresh returns None when no refreshToken is present."""
+        entry = {
+            "serverUrl": "https://mcp.slack.com/mcp",
+            "accessToken": "some-token",
+        }
+        result = bridge._refresh_slack_token(entry)
+        assert result is None
+
+    def test_refresh_api_failure(self, tmp_config):
+        """Refresh returns None when Slack API returns error."""
+        entry = {
+            "serverUrl": "https://mcp.slack.com/mcp",
+            "accessToken": "old-token",
+            "refreshToken": "refresh-123",
+        }
+        mock_response = json.dumps({"ok": False, "error": "invalid_refresh_token"}).encode()
+
+        with mock.patch("bridge.urlopen") as mock_urlopen, \
+             mock.patch.object(bridge, "_notify_refresh_failure"):
+            mock_resp = mock.MagicMock()
+            mock_resp.read.return_value = mock_response
+            mock_resp.__enter__ = mock.MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = mock.MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_resp
+
+            result = bridge._refresh_slack_token(entry)
+
+        assert result is None
+
+    def test_proactive_refresh_skipped_without_refresh_token(self, tmp_config):
+        """get_slack_token should not attempt refresh when no refreshToken."""
+        entry = {
+            "serverUrl": "https://mcp.slack.com/mcp",
+            "accessToken": "valid-token",
+            "expiresAt": int((time.time() + 1800) * 1000),  # 30 min left
+        }
+        token_file = tmp_config / "slack_mcp_token.json"
+        token_file.write_text(json.dumps(entry))
+
+        with mock.patch.object(bridge, "SLACK_TOKEN_FILE", token_file), \
+             mock.patch.object(bridge, "SLACK_TOKEN_REFRESH_HOURS", 2), \
+             mock.patch.object(bridge, "_refresh_slack_token") as mock_refresh:
+            token = bridge.get_slack_token()
+
+        assert token == "valid-token"
+        mock_refresh.assert_not_called()
 
 
 class TestMcpTextExtraction:


### PR DESCRIPTION
## Summary
- Fix README `chmod 600` description to match actual permissions (dir 700, files 600)
- Fix README `POLL_INTERVAL` default from 30 to 15 to match code
- Restore Slack posting guardrail in Claude prompts to prevent out-of-thread messages
- Gate proactive token refresh on presence of `refreshToken` to avoid warning spam
- Replace hard-coded repo path in refresh failure notification with dynamic `__file__` path
- Add tests for missing-skill case and token auto-refresh (6 new tests, 88 total)

## What are the consequences of this change?
- Claude sessions invoked from Slack will again include the "post only to current thread" constraint, reducing risk of data leakage
- Proactive refresh no longer spams `WARNING` logs every poll cycle when using Claude Code ephemeral credentials
- Refresh failure notifications now show the correct repo path regardless of install location
- README accurately reflects the code defaults

## Testing
- `python -m pytest test_bridge.py -v` - all 88 tests pass
- New tests cover: skill-not-installed skip, token refresh success/failure, proactive refresh gating

## Checklist
- [x] Code compiles without errors
- [x] Linter passes
- [x] Unit tests pass (88/88)
- [x] No redundant comments added